### PR TITLE
Implement Conjunction Primitive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -495,6 +495,32 @@ where
     }
 }
 
+/// Creates the conjunction of two goals, flattening the state for all states
+/// that are valid in both goals. Logically similar to an `and`.
+///
+/// # Examples
+///
+/// ```
+/// use kannery::*;
+///
+/// let goal = fresh(|mut state| {
+///     let a = state.define('a');
+///     let b = state.define('b');
+///     let c = state.define('c');
+///
+///     conjunction(
+///         eq(Term::<u8>::Var(a), Term::<u8>::Value(1)),
+///         conjunction(
+///             eq(Term::<u8>::Var(b), Term::<u8>::Value(2)),
+///             eq(Term::<u8>::Var(c), Term::<u8>::Value(3)),
+///         ),
+///     )
+///     .apply(state)
+/// });
+///
+/// let stream = goal.apply(State::empty());
+/// assert!(stream.len() == 1);
+/// ```
 pub fn conjunction<T>(goal1: impl Goal<T>, goal2: impl Goal<T>) -> impl Goal<T>
 where
     T: ValueRepresentable,


### PR DESCRIPTION
# Introduction
This PR introduces the conjunction primitive for defining goals that are a conjunction (logical `and`) of the states of two sub goals.

```rust
let a = 'a'.to_var_repr(0);

let goal = fresh(|mut state| {
    let a = state.declare('a');
    let b = state.declare('b');
    let c = state.declare('c');
    let d = state.declare('d');

    conjunction(
        eq(Term::<u8>::Var(a), Term::<u8>::Var(b)),
        conjunction(
            eq(Term::<u8>::Var(b), Term::<u8>::Var(c)),
            conjunction(
                eq(Term::<u8>::Var(c), Term::<u8>::Value(1)),
                eq(Term::<u8>::Var(d), Term::<u8>::Value(2)),
            ),
        ),
    )
    .apply(state)
});

let stream = goal.apply(State::empty());
assert!(stream.len() == 1);
assert_eq!(4, stream[0].as_ref().len(), "{:?}", stream[0]);
assert_eq!(Term::Value(1), stream[0].as_ref().walk(&Term::Var(a)));
```
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
