### PR TITLE
Better memory management around terms

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -537,35 +537,36 @@ mod tests {
     #[test]
     fn should_return_multiple_relations() {
         let parent_fn = |parent: Term<_>, child: Term<_>| {
+            let homer = value!("Homer");
+            let marge = value!("Marge");
+            let bart = value!("Bart");
+            let lisa = value!("Lisa");
+            let abe = value!("Abe");
+            let jackie = value!("Jackie");
+
             disjunction(
                 eq(
                     cons!(parent.clone(), child.clone()),
-                    cons!(value!("Homer"), value!("Bart")),
+                    cons!(homer.clone(), bart.clone()),
                 ),
                 disjunction(
                     eq(
                         cons!(parent.clone(), child.clone()),
-                        cons!(value!("Homer"), value!("Lisa")),
+                        cons!(homer.clone(), lisa.clone()),
                     ),
                     disjunction(
                         eq(
                             cons!(parent.clone(), child.clone()),
-                            cons!(value!("Marge"), value!("Bart")),
+                            cons!(marge.clone(), bart),
                         ),
                         disjunction(
                             eq(
                                 cons!(parent.clone(), child.clone()),
-                                cons!(value!("Marge"), value!("Lisa")),
+                                cons!(marge.clone(), lisa),
                             ),
                             disjunction(
-                                eq(
-                                    cons!(parent.clone(), child.clone()),
-                                    cons!(value!("Abe"), value!("Homer")),
-                                ),
-                                eq(
-                                    cons!(parent, child),
-                                    cons!(value!("Jackie"), value!("Marge")),
-                                ),
+                                eq(cons!(parent.clone(), child.clone()), cons!(abe, homer)),
+                                eq(cons!(parent, child), cons!(jackie, marge)),
                             ),
                         ),
                     ),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 use std::hash::Hash;
+use std::rc::Rc;
 
 #[macro_export]
 macro_rules! value {
     ($v:expr) => {
-        Term::Value($v)
+        Term::Value(Rc::new($v))
     };
 }
 
@@ -69,7 +70,7 @@ impl Var {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Term<T: ValueRepresentable> {
     Var(Var),
-    Value(T),
+    Value(Rc<T>),
     // In place of a traditional cons list.
     Cons(Box<Term<T>>, Box<Term<T>>),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -587,12 +587,10 @@ mod tests {
             elements
         };
 
-        let children_of_homer = || {
-            fresh("child", move |child| {
-                parent_fn(value!("Homer"), var!(child))
-            })
-        };
-        let stream = children_of_homer().apply(State::empty());
+        let children_of_homer = fresh("child", move |child| {
+            parent_fn(value!("Homer"), var!(child))
+        });
+        let stream = children_of_homer.apply(State::empty());
         let child_var = "child".to_var_repr(0);
         let res = stream.run(&var!(child_var));
 
@@ -604,12 +602,10 @@ mod tests {
         );
 
         // map parent relationship
-        let parents_of_lisa = || {
-            fresh("parent", move |parent| {
-                parent_fn(var!(parent), value!("Lisa"))
-            })
-        };
-        let stream = parents_of_lisa().apply(State::empty());
+        let parents_of_lisa = fresh("parent", move |parent| {
+            parent_fn(var!(parent), value!("Lisa"))
+        });
+        let stream = parents_of_lisa.apply(State::empty());
         let parent_var = "parent".to_var_repr(0);
         let res = stream.run(&Term::Var(parent_var));
 
@@ -691,8 +687,8 @@ mod tests {
         // map parent relationship
         let mut state = State::empty();
         let parent = state.declare("child");
-        let parents_of_lisa = || parent_fn(var!(parent), value!("Lisa"));
-        let stream = parents_of_lisa().apply(state);
+        let parents_of_lisa = parent_fn(var!(parent), value!("Lisa"));
+        let stream = parents_of_lisa.apply(state);
         let res = stream.run(&var!(parent));
 
         assert_eq!(stream.len(), 2, "{:?}", res);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,21 +3,21 @@ use std::hash::Hash;
 use std::rc::Rc;
 
 #[macro_export]
-macro_rules! value {
+macro_rules! value_term {
     ($v:expr) => {
         Term::Value(Rc::new($v))
     };
 }
 
 #[macro_export]
-macro_rules! var {
+macro_rules! var_term {
     ($var:expr) => {
         Term::Var($var)
     };
 }
 
 #[macro_export]
-macro_rules! cons {
+macro_rules! cons_term {
     ($head:expr, $tail:expr) => {
         Term::Cons(Box::new($head), Box::new($tail))
     };
@@ -77,7 +77,7 @@ pub enum Term<T: ValueRepresentable> {
 
 impl<T: ValueRepresentable> From<(Term<T>, Term<T>)> for Term<T> {
     fn from((head, tail): (Term<T>, Term<T>)) -> Self {
-        cons!(head, tail)
+        cons_term!(head, tail)
     }
 }
 
@@ -234,7 +234,7 @@ impl<T: VarRepresentable> DeepWalkable<T> for TermMapping<T> {
             let head_ref = self.walk(head.as_ref());
             let tail_ref = self.walk(tail.as_ref());
 
-            cons!(head_ref, tail_ref)
+            cons_term!(head_ref, tail_ref)
         } else {
             term
         }
@@ -537,36 +537,39 @@ mod tests {
     #[test]
     fn should_return_multiple_relations() {
         let parent_fn = |parent: Term<_>, child: Term<_>| {
-            let homer = value!("Homer");
-            let marge = value!("Marge");
-            let bart = value!("Bart");
-            let lisa = value!("Lisa");
-            let abe = value!("Abe");
-            let jackie = value!("Jackie");
+            let homer = value_term!("Homer");
+            let marge = value_term!("Marge");
+            let bart = value_term!("Bart");
+            let lisa = value_term!("Lisa");
+            let abe = value_term!("Abe");
+            let jackie = value_term!("Jackie");
 
             disjunction(
                 eq(
-                    cons!(parent.clone(), child.clone()),
-                    cons!(homer.clone(), bart.clone()),
+                    cons_term!(parent.clone(), child.clone()),
+                    cons_term!(homer.clone(), bart.clone()),
                 ),
                 disjunction(
                     eq(
-                        cons!(parent.clone(), child.clone()),
-                        cons!(homer.clone(), lisa.clone()),
+                        cons_term!(parent.clone(), child.clone()),
+                        cons_term!(homer.clone(), lisa.clone()),
                     ),
                     disjunction(
                         eq(
-                            cons!(parent.clone(), child.clone()),
-                            cons!(marge.clone(), bart),
+                            cons_term!(parent.clone(), child.clone()),
+                            cons_term!(marge.clone(), bart),
                         ),
                         disjunction(
                             eq(
-                                cons!(parent.clone(), child.clone()),
-                                cons!(marge.clone(), lisa),
+                                cons_term!(parent.clone(), child.clone()),
+                                cons_term!(marge.clone(), lisa),
                             ),
                             disjunction(
-                                eq(cons!(parent.clone(), child.clone()), cons!(abe, homer)),
-                                eq(cons!(parent, child), cons!(jackie, marge)),
+                                eq(
+                                    cons_term!(parent.clone(), child.clone()),
+                                    cons_term!(abe, homer),
+                                ),
+                                eq(cons_term!(parent, child), cons_term!(jackie, marge)),
                             ),
                         ),
                     ),
@@ -587,10 +590,12 @@ mod tests {
             elements
         };
 
-        let children_of_homer = fresh("child", |child| parent_fn(value!("Homer"), var!(child)));
+        let children_of_homer = fresh("child", |child| {
+            parent_fn(value_term!("Homer"), var_term!(child))
+        });
         let stream = children_of_homer.apply(State::empty());
         let child_var = "child".to_var_repr(0);
-        let res = stream.run(&var!(child_var));
+        let res = stream.run(&var_term!(child_var));
 
         assert_eq!(stream.len(), 2, "{:?}", res);
         let sorted_children = sorted_value_strings(res);
@@ -600,7 +605,9 @@ mod tests {
         );
 
         // map parent relationship
-        let parents_of_lisa = fresh("parent", |parent| parent_fn(var!(parent), value!("Lisa")));
+        let parents_of_lisa = fresh("parent", |parent| {
+            parent_fn(var_term!(parent), value_term!("Lisa"))
+        });
         let stream = parents_of_lisa.apply(State::empty());
         let parent_var = "parent".to_var_repr(0);
         let res = stream.run(&Term::Var(parent_var));
@@ -617,36 +624,39 @@ mod tests {
     #[test]
     fn should_define_relations_without_fresh() {
         let parent_fn = |parent: Term<_>, child: Term<_>| {
-            let homer = value!("Homer");
-            let marge = value!("Marge");
-            let bart = value!("Bart");
-            let lisa = value!("Lisa");
-            let abe = value!("Abe");
-            let jackie = value!("Jackie");
+            let homer = value_term!("Homer");
+            let marge = value_term!("Marge");
+            let bart = value_term!("Bart");
+            let lisa = value_term!("Lisa");
+            let abe = value_term!("Abe");
+            let jackie = value_term!("Jackie");
 
             disjunction(
                 eq(
-                    cons!(parent.clone(), child.clone()),
-                    cons!(homer.clone(), bart.clone()),
+                    cons_term!(parent.clone(), child.clone()),
+                    cons_term!(homer.clone(), bart.clone()),
                 ),
                 disjunction(
                     eq(
-                        cons!(parent.clone(), child.clone()),
-                        cons!(homer.clone(), lisa.clone()),
+                        cons_term!(parent.clone(), child.clone()),
+                        cons_term!(homer.clone(), lisa.clone()),
                     ),
                     disjunction(
                         eq(
-                            cons!(parent.clone(), child.clone()),
-                            cons!(marge.clone(), bart),
+                            cons_term!(parent.clone(), child.clone()),
+                            cons_term!(marge.clone(), bart),
                         ),
                         disjunction(
                             eq(
-                                cons!(parent.clone(), child.clone()),
-                                cons!(marge.clone(), lisa),
+                                cons_term!(parent.clone(), child.clone()),
+                                cons_term!(marge.clone(), lisa),
                             ),
                             disjunction(
-                                eq(cons!(parent.clone(), child.clone()), cons!(abe, homer)),
-                                eq(cons!(parent, child), cons!(jackie, marge)),
+                                eq(
+                                    cons_term!(parent.clone(), child.clone()),
+                                    cons_term!(abe, homer),
+                                ),
+                                eq(cons_term!(parent, child), cons_term!(jackie, marge)),
                             ),
                         ),
                     ),
@@ -669,7 +679,7 @@ mod tests {
 
         let mut state = State::empty();
         let child = state.declare("child");
-        let children_of_homer = || parent_fn(value!("Homer"), var!(child));
+        let children_of_homer = || parent_fn(value_term!("Homer"), var_term!(child));
         let stream = children_of_homer().apply(state);
         let res = stream.run(&Term::Var(child));
 
@@ -683,9 +693,9 @@ mod tests {
         // map parent relationship
         let mut state = State::empty();
         let parent = state.declare("child");
-        let parents_of_lisa = parent_fn(var!(parent), value!("Lisa"));
+        let parents_of_lisa = parent_fn(var_term!(parent), value_term!("Lisa"));
         let stream = parents_of_lisa.apply(state);
-        let res = stream.run(&var!(parent));
+        let res = stream.run(&var_term!(parent));
 
         assert_eq!(stream.len(), 2, "{:?}", res);
         let sorted_parents = sorted_value_strings(res);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -587,9 +587,7 @@ mod tests {
             elements
         };
 
-        let children_of_homer = fresh("child", move |child| {
-            parent_fn(value!("Homer"), var!(child))
-        });
+        let children_of_homer = fresh("child", |child| parent_fn(value!("Homer"), var!(child)));
         let stream = children_of_homer.apply(State::empty());
         let child_var = "child".to_var_repr(0);
         let res = stream.run(&var!(child_var));
@@ -602,9 +600,7 @@ mod tests {
         );
 
         // map parent relationship
-        let parents_of_lisa = fresh("parent", move |parent| {
-            parent_fn(var!(parent), value!("Lisa"))
-        });
+        let parents_of_lisa = fresh("parent", |parent| parent_fn(var!(parent), value!("Lisa")));
         let stream = parents_of_lisa.apply(State::empty());
         let parent_var = "parent".to_var_repr(0);
         let res = stream.run(&Term::Var(parent_var));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -675,10 +675,10 @@ mod tests {
             elements
         };
 
-        let mut state = State::<&str>::empty();
+        let mut state = State::empty();
         let child = state.declare("child");
         let children_of_homer = || parent_fn(value!("Homer"), var!(child));
-        let stream = children_of_homer().apply(State::empty());
+        let stream = children_of_homer().apply(state);
         let res = stream.run(&Term::Var(child));
 
         assert_eq!(stream.len(), 2, "{:?}", res);
@@ -689,10 +689,10 @@ mod tests {
         );
 
         // map parent relationship
-        let mut state = State::<&str>::empty();
+        let mut state = State::empty();
         let parent = state.declare("child");
         let parents_of_lisa = || parent_fn(var!(parent), value!("Lisa"));
-        let stream = parents_of_lisa().apply(State::empty());
+        let stream = parents_of_lisa().apply(state);
         let res = stream.run(&var!(parent));
 
         assert_eq!(stream.len(), 2, "{:?}", res);


### PR DESCRIPTION
# Introduction
Improve memory usage by wrapping `Term::Value` inner data in `Rc` to cause cheaper copies.

## Other Changes
- updated term creation macros for more clarity
  - `value!()` -> `value_term!()`
  - `var!()` -> `var_term!()`
  - `cons!() -> `cons_term!()`
- Added a test showing variable declaration directly on `State`.
- Additional documentation and examples.

# Linked Issues
resolves #18 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
