### PR TITLE
Replace macro with method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,30 +1,6 @@
 use std::collections::HashMap;
 use std::hash::Hash;
 
-/// A helper macro for creating a `Rc`-wrapped `Term::Value` variant.
-#[macro_export]
-macro_rules! value_term {
-    ($v:expr) => {
-        $crate::Term::Value(std::rc::Rc::new($v))
-    };
-}
-
-/// A helper macro for creating a `Term::Var` variant.
-#[macro_export]
-macro_rules! var_term {
-    ($var:expr) => {
-        $crate::Term::Var($var)
-    };
-}
-
-/// A helper macro for creating a `Term::Cons` variant from two sub-`Term`s.
-#[macro_export]
-macro_rules! cons_term {
-    ($head:expr, $tail:expr) => {
-        $crate::Term::Cons(Box::new($head), Box::new($tail))
-    };
-}
-
 /// Any type that can be represented as a `Var`.
 pub trait VarRepresentable: Sized + Clone + Hash + Eq {
     fn to_var_repr(&self, count: usize) -> Var {
@@ -79,9 +55,23 @@ pub enum Term<T: ValueRepresentable> {
     Cons(Box<Term<T>>, Box<Term<T>>),
 }
 
+impl<T: ValueRepresentable> Term<T> {
+    pub fn var(var: Var) -> Self {
+        Term::Var(var)
+    }
+
+    pub fn value(val: T) -> Self {
+        Term::Value(std::rc::Rc::new(val))
+    }
+
+    pub fn cons(head: Self, tail: Self) -> Self {
+        Term::Cons(Box::new(head), Box::new(tail))
+    }
+}
+
 impl<T: ValueRepresentable> From<(Term<T>, Term<T>)> for Term<T> {
     fn from((head, tail): (Term<T>, Term<T>)) -> Self {
-        cons_term!(head, tail)
+        Term::cons(head, tail)
     }
 }
 
@@ -255,7 +245,7 @@ impl<T: VarRepresentable> DeepWalkable<T> for TermMapping<T> {
             let head_ref = self.walk(head.as_ref());
             let tail_ref = self.walk(tail.as_ref());
 
-            cons_term!(head_ref, tail_ref)
+            Term::cons(head_ref, tail_ref)
         } else {
             term
         }
@@ -347,7 +337,7 @@ where
 /// use kannery::*;
 ///
 /// let _x_equals = Fresh::new("x", |x| {
-///     eq(var_term!(x), value_term!(1))
+///     eq(Term::var(x), Term::value(1))
 /// });
 /// ```
 #[derive(Debug)]
@@ -379,7 +369,7 @@ where
     /// use kannery::*;
     ///
     /// let _x_equals = Fresh::new("x", |x| {
-    ///     eq(var_term!(x), value_term!(1))
+    ///     eq(Term::var(x), Term::value(1))
     /// });
     /// ```
     pub fn new(var_id: V, func: F) -> Self {
@@ -412,7 +402,7 @@ where
 /// use kannery::*;
 ///
 /// let _x_equals = fresh("x", |x| {
-///     eq(var_term!(x), value_term!(1))
+///     eq(Term::var(x), Term::value(1))
 /// });
 /// ```
 pub fn fresh<T, V, GO>(var: V, func: impl Fn(Var) -> GO) -> impl Goal<T>
@@ -434,7 +424,7 @@ where
 /// use kannery::*;
 ///
 /// let _x_equals = declare("x", |x| {
-///     eq(var_term!(x), value_term!(1))
+///     eq(Term::var(x), Term::value(1))
 /// });
 /// ```
 pub fn declare<T, V, GO>(var: V, func: impl Fn(Var) -> GO) -> impl Goal<T>
@@ -479,14 +469,14 @@ where
 /// use kannery::*;
 ///
 /// let x_equals = fresh('x', |x| {
-///     Equal::new(var_term!(x), value_term!(1))
+///     Equal::new(Term::var(x), Term::value(1))
 /// });
 /// let stream = x_equals.apply(State::<u8>::empty());
 /// let x_var = 'x'.to_var_repr(0);
-/// let res = stream.run(&var_term!(x_var));
+/// let res = stream.run(&Term::var(x_var));
 ///
 /// assert_eq!(res.len(), 1);
-/// assert_eq!([value_term!(1)].as_slice(), res.as_slice());
+/// assert_eq!([Term::value(1)].as_slice(), res.as_slice());
 /// ```
 #[derive(Debug)]
 pub struct Equal<T: ValueRepresentable> {
@@ -503,14 +493,14 @@ impl<T: ValueRepresentable> Equal<T> {
     /// use kannery::*;
     ///
     /// let x_equals = fresh('x', |x| {
-    ///     Equal::new(var_term!(x), value_term!(1))
+    ///     Equal::new(Term::var(x), Term::value(1))
     /// });
     /// let stream = x_equals.apply(State::<u8>::empty());
     /// let x_var = 'x'.to_var_repr(0);
-    /// let res = stream.run(&var_term!(x_var));
+    /// let res = stream.run(&Term::var(x_var));
     ///
     /// assert_eq!(res.len(), 1);
-    /// assert_eq!([value_term!(1)].as_slice(), res.as_slice());
+    /// assert_eq!([Term::value(1)].as_slice(), res.as_slice());
     /// ```
     pub fn new(term1: Term<T>, term2: Term<T>) -> Self {
         Self { term1, term2 }
@@ -531,14 +521,14 @@ impl<T: VarRepresentable> Goal<T> for Equal<T> {
 /// use kannery::*;
 ///
 /// let x_equals = fresh('x', |x| {
-///     equal(var_term!(x), value_term!(1))
+///     equal(Term::var(x), Term::value(1))
 /// });
 /// let stream = x_equals.apply(State::<u8>::empty());
 /// let x_var = 'x'.to_var_repr(0);
-/// let res = stream.run(&var_term!(x_var));
+/// let res = stream.run(&Term::var(x_var));
 ///
 /// assert_eq!(res.len(), 1);
-/// assert_eq!([value_term!(1)].as_slice(), res.as_slice());
+/// assert_eq!([Term::value(1)].as_slice(), res.as_slice());
 /// ```
 pub fn equal<T>(term1: Term<T>, term2: Term<T>) -> impl Goal<T>
 where
@@ -558,14 +548,14 @@ where
 /// use kannery::*;
 ///
 /// let x_equals = fresh('x', |x| {
-///     eq(var_term!(x), value_term!(1))
+///     eq(Term::var(x), Term::value(1))
 /// });
 /// let stream = x_equals.apply(State::<u8>::empty());
 /// let x_var = 'x'.to_var_repr(0);
-/// let res = stream.run(&var_term!(x_var));
+/// let res = stream.run(&Term::var(x_var));
 ///
 /// assert_eq!(res.len(), 1);
-/// assert_eq!([value_term!(1)].as_slice(), res.as_slice());
+/// assert_eq!([Term::value(1)].as_slice(), res.as_slice());
 /// ```
 pub fn eq<T>(term1: Term<T>, term2: Term<T>) -> impl Goal<T>
 where
@@ -585,18 +575,18 @@ where
 /// let x_equals = fresh('x', |x| {
 ///     conjunction(
 ///         disjunction(
-///             equal(var_term!(x), value_term!(1)),
-///             equal(var_term!(x), value_term!(2))
+///             equal(Term::var(x), Term::value(1)),
+///             equal(Term::var(x), Term::value(2))
 ///         ),
-///         NotEqual::new(var_term!(x), value_term!(1))
+///         NotEqual::new(Term::var(x), Term::value(1))
 ///     )
 /// });
 /// let stream = x_equals.apply(State::<u8>::empty());
 /// let x_var = 'x'.to_var_repr(0);
-/// let res = stream.run(&var_term!(x_var));
+/// let res = stream.run(&Term::var(x_var));
 ///
 /// assert_eq!(res.len(), 1);
-/// assert_eq!([value_term!(2)].as_slice(), res.as_slice());
+/// assert_eq!([Term::value(2)].as_slice(), res.as_slice());
 /// ```
 #[derive(Debug)]
 pub struct NotEqual<T: ValueRepresentable> {
@@ -615,18 +605,18 @@ impl<T: ValueRepresentable> NotEqual<T> {
     /// let x_equals = fresh('x', |x| {
     ///     conjunction(
     ///         disjunction(
-    ///             equal(var_term!(x), value_term!(1)),
-    ///             equal(var_term!(x), value_term!(2))
+    ///             equal(Term::var(x), Term::value(1)),
+    ///             equal(Term::var(x), Term::value(2))
     ///         ),
-    ///         NotEqual::new(var_term!(x), value_term!(1))
+    ///         NotEqual::new(Term::var(x), Term::value(1))
     ///     )
     /// });
     /// let stream = x_equals.apply(State::<u8>::empty());
     /// let x_var = 'x'.to_var_repr(0);
-    /// let res = stream.run(&var_term!(x_var));
+    /// let res = stream.run(&Term::var(x_var));
     ///
     /// assert_eq!(res.len(), 1);
-    /// assert_eq!([value_term!(2)].as_slice(), res.as_slice());
+    /// assert_eq!([Term::value(2)].as_slice(), res.as_slice());
     /// ```
     pub fn new(term1: Term<T>, term2: Term<T>) -> Self {
         Self { term1, term2 }
@@ -649,18 +639,18 @@ impl<T: VarRepresentable> Goal<T> for NotEqual<T> {
 /// let x_equals = fresh('x', |x| {
 ///     conjunction(
 ///         disjunction(
-///             equal(var_term!(x), value_term!(1)),
-///             equal(var_term!(x), value_term!(2))
+///             equal(Term::var(x), Term::value(1)),
+///             equal(Term::var(x), Term::value(2))
 ///         ),
-///         not_equal(var_term!(x), value_term!(1))
+///         not_equal(Term::var(x), Term::value(1))
 ///     )
 /// });
 /// let stream = x_equals.apply(State::<u8>::empty());
 /// let x_var = 'x'.to_var_repr(0);
-/// let res = stream.run(&var_term!(x_var));
+/// let res = stream.run(&Term::var(x_var));
 ///
 /// assert_eq!(res.len(), 1);
-/// assert_eq!([value_term!(2)].as_slice(), res.as_slice());
+/// assert_eq!([Term::value(2)].as_slice(), res.as_slice());
 /// ```
 pub fn not_equal<T>(term1: Term<T>, term2: Term<T>) -> impl Goal<T>
 where
@@ -682,18 +672,18 @@ where
 /// let x_equals = fresh('x', |x| {
 ///     conjunction(
 ///         disjunction(
-///             equal(var_term!(x), value_term!(1)),
-///             equal(var_term!(x), value_term!(2))
+///             equal(Term::var(x), Term::value(1)),
+///             equal(Term::var(x), Term::value(2))
 ///         ),
-///         neq(var_term!(x), value_term!(1))
+///         neq(Term::var(x), Term::value(1))
 ///     )
 /// });
 /// let stream = x_equals.apply(State::<u8>::empty());
 /// let x_var = 'x'.to_var_repr(0);
-/// let res = stream.run(&var_term!(x_var));
+/// let res = stream.run(&Term::var(x_var));
 ///
 /// assert_eq!(res.len(), 1);
-/// assert_eq!([value_term!(2)].as_slice(), res.as_slice());
+/// assert_eq!([Term::value(2)].as_slice(), res.as_slice());
 /// ```
 pub fn neq<T>(term1: Term<T>, term2: Term<T>) -> impl Goal<T>
 where
@@ -714,18 +704,18 @@ where
 ///     fresh('x', move |x| {
 ///         conjunction(
 ///             disjunction(
-///                 equal(var_term!(x), value_term!(1)),
-///                 equal(var_term!(x), value_term!(2)),
+///                 equal(Term::var(x), Term::value(1)),
+///                 equal(Term::var(x), Term::value(2)),
 ///             ),
-///             LessThan::new(var_term!(x), value_term!(max)),
+///             LessThan::new(Term::var(x), Term::value(max)),
 ///         )
 ///     })
 /// };
 /// let stream = x_is_less_than(2).apply(State::<u8>::empty());
 /// let x_var = 'x'.to_var_repr(0);
-/// let res = stream.run(&var_term!(x_var));
+/// let res = stream.run(&Term::var(x_var));
 /// assert_eq!(res.len(), 1);
-/// assert_eq!([value_term!(1)].as_slice(), res.as_slice());
+/// assert_eq!([Term::value(1)].as_slice(), res.as_slice());
 /// ```
 #[derive(Debug)]
 pub struct LessThan<T: ValueRepresentable + PartialOrd> {
@@ -745,18 +735,18 @@ impl<T: ValueRepresentable + PartialOrd> LessThan<T> {
     ///     fresh('x', move |x| {
     ///         conjunction(
     ///             disjunction(
-    ///                 equal(var_term!(x), value_term!(1)),
-    ///                 equal(var_term!(x), value_term!(2)),
+    ///                 equal(Term::var(x), Term::value(1)),
+    ///                 equal(Term::var(x), Term::value(2)),
     ///             ),
-    ///             LessThan::new(var_term!(x), value_term!(max)),
+    ///             LessThan::new(Term::var(x), Term::value(max)),
     ///         )
     ///     })
     /// };
     /// let stream = x_is_less_than(2).apply(State::<u8>::empty());
     /// let x_var = 'x'.to_var_repr(0);
-    /// let res = stream.run(&var_term!(x_var));
+    /// let res = stream.run(&Term::var(x_var));
     /// assert_eq!(res.len(), 1);
-    /// assert_eq!([value_term!(1)].as_slice(), res.as_slice());
+    /// assert_eq!([Term::value(1)].as_slice(), res.as_slice());
     /// ```
     pub fn new(term1: Term<T>, term2: Term<T>) -> Self {
         Self { term1, term2 }
@@ -783,18 +773,18 @@ where
 ///     fresh('x', move |x| {
 ///         conjunction(
 ///             disjunction(
-///                 equal(var_term!(x), value_term!(1)),
-///                 equal(var_term!(x), value_term!(2)),
+///                 equal(Term::var(x), Term::value(1)),
+///                 equal(Term::var(x), Term::value(2)),
 ///             ),
-///             less_than(var_term!(x), value_term!(max)),
+///             less_than(Term::var(x), Term::value(max)),
 ///         )
 ///     })
 /// };
 /// let stream = x_is_less_than(2).apply(State::<u8>::empty());
 /// let x_var = 'x'.to_var_repr(0);
-/// let res = stream.run(&var_term!(x_var));
+/// let res = stream.run(&Term::var(x_var));
 /// assert_eq!(res.len(), 1);
-/// assert_eq!([value_term!(1)].as_slice(), res.as_slice());
+/// assert_eq!([Term::value(1)].as_slice(), res.as_slice());
 /// ```
 pub fn less_than<T>(term1: Term<T>, term2: Term<T>) -> impl Goal<T>
 where
@@ -816,18 +806,18 @@ where
 ///     fresh('x', move |x| {
 ///         conjunction(
 ///             disjunction(
-///                 equal(var_term!(x), value_term!(1)),
-///                 equal(var_term!(x), value_term!(2)),
+///                 equal(Term::var(x), Term::value(1)),
+///                 equal(Term::var(x), Term::value(2)),
 ///             ),
-///             LessEqual::new(var_term!(x), value_term!(max)),
+///             LessEqual::new(Term::var(x), Term::value(max)),
 ///         )
 ///     })
 /// };
 /// let stream = x_is_less_than_or_equal_to(2).apply(State::<u8>::empty());
 /// let x_var = 'x'.to_var_repr(0);
-/// let res = stream.run(&var_term!(x_var));
+/// let res = stream.run(&Term::var(x_var));
 /// assert_eq!(res.len(), 2);
-/// assert_eq!([value_term!(1), value_term!(2)].as_slice(), res.as_slice());
+/// assert_eq!([Term::value(1), Term::value(2)].as_slice(), res.as_slice());
 /// ```
 #[derive(Debug)]
 pub struct LessEqual<T: ValueRepresentable + PartialOrd> {
@@ -847,18 +837,18 @@ impl<T: ValueRepresentable + PartialOrd> LessEqual<T> {
     ///     fresh('x', move |x| {
     ///         conjunction(
     ///             disjunction(
-    ///                 equal(var_term!(x), value_term!(1)),
-    ///                 equal(var_term!(x), value_term!(2)),
+    ///                 equal(Term::var(x), Term::value(1)),
+    ///                 equal(Term::var(x), Term::value(2)),
     ///             ),
-    ///             LessEqual::new(var_term!(x), value_term!(max)),
+    ///             LessEqual::new(Term::var(x), Term::value(max)),
     ///         )
     ///     })
     /// };
     /// let stream = x_is_less_than_or_equal_to(2).apply(State::<u8>::empty());
     /// let x_var = 'x'.to_var_repr(0);
-    /// let res = stream.run(&var_term!(x_var));
+    /// let res = stream.run(&Term::var(x_var));
     /// assert_eq!(res.len(), 2);
-    /// assert_eq!([value_term!(1), value_term!(2)].as_slice(), res.as_slice());
+    /// assert_eq!([Term::value(1), Term::value(2)].as_slice(), res.as_slice());
     /// ```
     pub fn new(term1: Term<T>, term2: Term<T>) -> Self {
         Self { term1, term2 }
@@ -886,18 +876,18 @@ where
 ///     fresh('x', move |x| {
 ///         conjunction(
 ///             disjunction(
-///                 equal(var_term!(x), value_term!(1)),
-///                 equal(var_term!(x), value_term!(2)),
+///                 equal(Term::var(x), Term::value(1)),
+///                 equal(Term::var(x), Term::value(2)),
 ///             ),
-///             less_than_or_equal_to(var_term!(x), value_term!(max)),
+///             less_than_or_equal_to(Term::var(x), Term::value(max)),
 ///         )
 ///     })
 /// };
 /// let stream = x_is_less_than_or_equal_to(2).apply(State::<u8>::empty());
 /// let x_var = 'x'.to_var_repr(0);
-/// let res = stream.run(&var_term!(x_var));
+/// let res = stream.run(&Term::var(x_var));
 /// assert_eq!(res.len(), 2);
-/// assert_eq!([value_term!(1), value_term!(2)].as_slice(), res.as_slice());
+/// assert_eq!([Term::value(1), Term::value(2)].as_slice(), res.as_slice());
 /// ```
 pub fn less_than_or_equal_to<T>(term1: Term<T>, term2: Term<T>) -> impl Goal<T>
 where
@@ -918,18 +908,18 @@ where
 ///     fresh('x', move |x| {
 ///         conjunction(
 ///             disjunction(
-///                 equal(var_term!(x), value_term!(1)),
-///                 equal(var_term!(x), value_term!(2)),
+///                 equal(Term::var(x), Term::value(1)),
+///                 equal(Term::var(x), Term::value(2)),
 ///             ),
-///             GreaterThan::new(var_term!(x), value_term!(min)),
+///             GreaterThan::new(Term::var(x), Term::value(min)),
 ///         )
 ///     })
 /// };
 /// let stream = x_is_greater_than(1).apply(State::<u8>::empty());
 /// let x_var = 'x'.to_var_repr(0);
-/// let res = stream.run(&var_term!(x_var));
+/// let res = stream.run(&Term::var(x_var));
 /// assert_eq!(res.len(), 1);
-/// assert_eq!([value_term!(2)].as_slice(), res.as_slice());
+/// assert_eq!([Term::value(2)].as_slice(), res.as_slice());
 /// ```
 #[derive(Debug)]
 pub struct GreaterThan<T: ValueRepresentable + PartialOrd> {
@@ -949,18 +939,18 @@ impl<T: ValueRepresentable + PartialOrd> GreaterThan<T> {
     ///     fresh('x', move |x| {
     ///         conjunction(
     ///             disjunction(
-    ///                 equal(var_term!(x), value_term!(1)),
-    ///                 equal(var_term!(x), value_term!(2)),
+    ///                 equal(Term::var(x), Term::value(1)),
+    ///                 equal(Term::var(x), Term::value(2)),
     ///             ),
-    ///             GreaterThan::new(var_term!(x), value_term!(min)),
+    ///             GreaterThan::new(Term::var(x), Term::value(min)),
     ///         )
     ///     })
     /// };
     /// let stream = x_is_greater_than(1).apply(State::<u8>::empty());
     /// let x_var = 'x'.to_var_repr(0);
-    /// let res = stream.run(&var_term!(x_var));
+    /// let res = stream.run(&Term::var(x_var));
     /// assert_eq!(res.len(), 1);
-    /// assert_eq!([value_term!(2)].as_slice(), res.as_slice());
+    /// assert_eq!([Term::value(2)].as_slice(), res.as_slice());
     /// ```
     pub fn new(term1: Term<T>, term2: Term<T>) -> Self {
         Self { term1, term2 }
@@ -987,18 +977,18 @@ where
 ///     fresh('x', move |x| {
 ///         conjunction(
 ///             disjunction(
-///                 equal(var_term!(x), value_term!(1)),
-///                 equal(var_term!(x), value_term!(2)),
+///                 equal(Term::var(x), Term::value(1)),
+///                 equal(Term::var(x), Term::value(2)),
 ///             ),
-///             greater_than(var_term!(x), value_term!(min)),
+///             greater_than(Term::var(x), Term::value(min)),
 ///         )
 ///     })
 /// };
 /// let stream = x_is_greater_than(1).apply(State::<u8>::empty());
 /// let x_var = 'x'.to_var_repr(0);
-/// let res = stream.run(&var_term!(x_var));
+/// let res = stream.run(&Term::var(x_var));
 /// assert_eq!(res.len(), 1);
-/// assert_eq!([value_term!(2)].as_slice(), res.as_slice());
+/// assert_eq!([Term::value(2)].as_slice(), res.as_slice());
 /// ```
 pub fn greater_than<T>(term1: Term<T>, term2: Term<T>) -> impl Goal<T>
 where
@@ -1020,18 +1010,18 @@ where
 ///     fresh('x', move |x| {
 ///         conjunction(
 ///             disjunction(
-///                 equal(var_term!(x), value_term!(1)),
-///                 equal(var_term!(x), value_term!(2)),
+///                 equal(Term::var(x), Term::value(1)),
+///                 equal(Term::var(x), Term::value(2)),
 ///             ),
-///             GreaterEqual::new(var_term!(x), value_term!(min)),
+///             GreaterEqual::new(Term::var(x), Term::value(min)),
 ///         )
 ///     })
 /// };
 /// let stream = x_is_greater_than(1).apply(State::<u8>::empty());
 /// let x_var = 'x'.to_var_repr(0);
-/// let res = stream.run(&var_term!(x_var));
+/// let res = stream.run(&Term::var(x_var));
 /// assert_eq!(res.len(), 2);
-/// assert_eq!([value_term!(1), value_term!(2)].as_slice(), res.as_slice());
+/// assert_eq!([Term::value(1), Term::value(2)].as_slice(), res.as_slice());
 /// ```
 #[derive(Debug)]
 pub struct GreaterEqual<T: ValueRepresentable + PartialOrd> {
@@ -1051,18 +1041,18 @@ impl<T: ValueRepresentable + PartialOrd> GreaterEqual<T> {
     ///     fresh('x', move |x| {
     ///         conjunction(
     ///             disjunction(
-    ///                 equal(var_term!(x), value_term!(1)),
-    ///                 equal(var_term!(x), value_term!(2)),
+    ///                 equal(Term::var(x), Term::value(1)),
+    ///                 equal(Term::var(x), Term::value(2)),
     ///             ),
-    ///             GreaterEqual::new(var_term!(x), value_term!(min)),
+    ///             GreaterEqual::new(Term::var(x), Term::value(min)),
     ///         )
     ///     })
     /// };
     /// let stream = x_is_greater_than(1).apply(State::<u8>::empty());
     /// let x_var = 'x'.to_var_repr(0);
-    /// let res = stream.run(&var_term!(x_var));
+    /// let res = stream.run(&Term::var(x_var));
     /// assert_eq!(res.len(), 2);
-    /// assert_eq!([value_term!(1), value_term!(2)].as_slice(), res.as_slice());
+    /// assert_eq!([Term::value(1), Term::value(2)].as_slice(), res.as_slice());
     /// ```
     pub fn new(term1: Term<T>, term2: Term<T>) -> Self {
         Self { term1, term2 }
@@ -1090,18 +1080,18 @@ where
 ///     fresh('x', move |x| {
 ///         conjunction(
 ///             disjunction(
-///                 equal(var_term!(x), value_term!(1)),
-///                 equal(var_term!(x), value_term!(2)),
+///                 equal(Term::var(x), Term::value(1)),
+///                 equal(Term::var(x), Term::value(2)),
 ///             ),
-///             greater_than_or_equal_to(var_term!(x), value_term!(min)),
+///             greater_than_or_equal_to(Term::var(x), Term::value(min)),
 ///         )
 ///     })
 /// };
 /// let stream = x_is_greater_than(1).apply(State::<u8>::empty());
 /// let x_var = 'x'.to_var_repr(0);
-/// let res = stream.run(&var_term!(x_var));
+/// let res = stream.run(&Term::var(x_var));
 /// assert_eq!(res.len(), 2);
-/// assert_eq!([value_term!(1), value_term!(2)].as_slice(), res.as_slice());
+/// assert_eq!([Term::value(1), Term::value(2)].as_slice(), res.as_slice());
 /// ```
 pub fn greater_than_or_equal_to<T>(term1: Term<T>, term2: Term<T>) -> impl Goal<T>
 where
@@ -1120,16 +1110,16 @@ where
 ///
 /// let x_equals = fresh('x', |x| {
 ///     Disjunction::new(
-///         equal(var_term!(x), value_term!(1)),
-///         equal(var_term!(x), value_term!(2))
+///         equal(Term::var(x), Term::value(1)),
+///         equal(Term::var(x), Term::value(2))
 ///     )
 /// });
 /// let stream = x_equals.apply(State::<u8>::empty());
 /// let x_var = 'x'.to_var_repr(0);
-/// let res = stream.run(&var_term!(x_var));
+/// let res = stream.run(&Term::var(x_var));
 ///
 /// assert_eq!(res.len(), 2);
-/// assert_eq!([value_term!(1), value_term!(2)].as_slice(), res.as_slice());
+/// assert_eq!([Term::value(1), Term::value(2)].as_slice(), res.as_slice());
 /// ```
 pub struct Disjunction<T, G1, G2>
 where
@@ -1156,8 +1146,8 @@ where
     /// use kannery::*;
     ///
     /// let _x_equals = Disjunction::new(
-    ///     equal(value_term!(1), value_term!(1)),
-    ///     equal(value_term!(2), value_term!(2))
+    ///     equal(Term::value(1), Term::value(1)),
+    ///     equal(Term::value(2), Term::value(2))
     /// );
     /// ```
     pub fn new(goal1: G1, goal2: G2) -> Self {
@@ -1195,16 +1185,16 @@ where
 ///
 /// let x_equals = fresh('x', |x| {
 ///     disjunction(
-///         equal(var_term!(x), value_term!(1)),
-///         equal(var_term!(x), value_term!(2))
+///         equal(Term::var(x), Term::value(1)),
+///         equal(Term::var(x), Term::value(2))
 ///     )
 /// });
 /// let stream = x_equals.apply(State::<u8>::empty());
 /// let x_var = 'x'.to_var_repr(0);
-/// let res = stream.run(&var_term!(x_var));
+/// let res = stream.run(&Term::var(x_var));
 ///
 /// assert_eq!(res.len(), 2);
-/// assert_eq!([value_term!(1), value_term!(2)].as_slice(), res.as_slice());
+/// assert_eq!([Term::value(1), Term::value(2)].as_slice(), res.as_slice());
 /// ```
 pub fn disjunction<T>(goal1: impl Goal<T>, goal2: impl Goal<T>) -> impl Goal<T>
 where
@@ -1225,16 +1215,16 @@ where
 ///
 /// let x_equals = declare('x', |x| {
 ///     either(
-///         equal(var_term!(x), value_term!(1)),
-///         equal(var_term!(x), value_term!(2))
+///         equal(Term::var(x), Term::value(1)),
+///         equal(Term::var(x), Term::value(2))
 ///     )
 /// });
 /// let stream = x_equals.apply(State::<u8>::empty());
 /// let x_var = 'x'.to_var_repr(0);
-/// let res = stream.run(&var_term!(x_var));
+/// let res = stream.run(&Term::var(x_var));
 ///
 /// assert_eq!(res.len(), 2);
-/// assert_eq!([value_term!(1), value_term!(2)].as_slice(), res.as_slice());
+/// assert_eq!([Term::value(1), Term::value(2)].as_slice(), res.as_slice());
 /// ```
 pub fn either<T>(goal1: impl Goal<T>, goal2: impl Goal<T>) -> impl Goal<T>
 where
@@ -1253,17 +1243,17 @@ where
 /// let x_equals = fresh('x', |x| {
 ///     fresh('y', move |y| {
 ///         Conjunction::new(
-///             equal(var_term!(x), var_term!(y)),
-///             equal(var_term!(y), value_term!(1))
+///             equal(Term::var(x), Term::var(y)),
+///             equal(Term::var(y), Term::value(1))
 ///         )
 ///     })
 /// });
 /// let stream = x_equals.apply(State::<u8>::empty());
 /// let x_var = 'x'.to_var_repr(0);
-/// let res = stream.run(&var_term!(x_var));
+/// let res = stream.run(&Term::var(x_var));
 ///
 /// assert_eq!(res.len(), 1);
-/// assert_eq!([value_term!(1)].as_slice(), res.as_slice());
+/// assert_eq!([Term::value(1)].as_slice(), res.as_slice());
 /// ```
 pub struct Conjunction<T, G1, G2>
 where
@@ -1317,17 +1307,17 @@ where
 /// let x_equals = fresh('x', |x| {
 ///     fresh('y', move |y| {
 ///         conjunction(
-///             equal(var_term!(x), var_term!(y)),
-///             equal(var_term!(y), value_term!(1))
+///             equal(Term::var(x), Term::var(y)),
+///             equal(Term::var(y), Term::value(1))
 ///         )
 ///     })
 /// });
 /// let stream = x_equals.apply(State::<u8>::empty());
 /// let x_var = 'x'.to_var_repr(0);
-/// let res = stream.run(&var_term!(x_var));
+/// let res = stream.run(&Term::var(x_var));
 ///
 /// assert_eq!(res.len(), 1);
-/// assert_eq!([value_term!(1)].as_slice(), res.as_slice());
+/// assert_eq!([Term::value(1)].as_slice(), res.as_slice());
 /// ```
 pub fn conjunction<T>(goal1: impl Goal<T>, goal2: impl Goal<T>) -> impl Goal<T>
 where
@@ -1349,17 +1339,17 @@ where
 /// let x_equals = declare('x', |x| {
 ///     declare('y', move |y| {
 ///         both(
-///             equal(var_term!(x), var_term!(y)),
-///             equal(var_term!(y), value_term!(1))
+///             equal(Term::var(x), Term::var(y)),
+///             equal(Term::var(y), Term::value(1))
 ///         )
 ///     })
 /// });
 /// let stream = x_equals.apply(State::<u8>::empty());
 /// let x_var = 'x'.to_var_repr(0);
-/// let res = stream.run(&var_term!(x_var));
+/// let res = stream.run(&Term::var(x_var));
 ///
 /// assert_eq!(res.len(), 1);
-/// assert_eq!([value_term!(1)].as_slice(), res.as_slice());
+/// assert_eq!([Term::value(1)].as_slice(), res.as_slice());
 /// ```
 pub fn both<T>(goal1: impl Goal<T>, goal2: impl Goal<T>) -> impl Goal<T>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,14 +56,56 @@ pub enum Term<T: ValueRepresentable> {
 }
 
 impl<T: ValueRepresentable> Term<T> {
+    /// Instantiates a new `Term::Var` variant from a var.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kannery::*;
+    ///
+    /// let var = 0_u8.to_var_repr(0);  
+    /// let term = Term::<u8>::var(var);
+    ///
+    /// assert_eq!(Term::Var(var), term);
+    /// ```
     pub fn var(var: Var) -> Self {
         Term::Var(var)
     }
 
+    /// Instantiates a new `Term::Value` variant from a value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kannery::*;
+    /// use std::rc::Rc;
+    ///
+    /// let term = Term::value(0_u8);
+    ///
+    /// assert_eq!(term, Term::Value(Rc::new(0_u8)));
+    /// ```
     pub fn value(val: T) -> Self {
         Term::Value(std::rc::Rc::new(val))
     }
 
+    /// Instantiates a new `Term::cons` variant from two `Term`s.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kannery::*;
+    /// use std::rc::Rc;
+    ///
+    /// let term1 = Term::value(0_u8);
+    /// let term2 = Term::value(1_u8);
+    ///
+    /// let expected = Term::Cons(
+    ///     Box::new(Term::Value(Rc::new(0))),
+    ///     Box::new(Term::Value(Rc::new(1)))
+    /// );
+    ///
+    /// assert_eq!(Term::cons(term1, term2), expected);
+    /// ```
     pub fn cons(head: Self, tail: Self) -> Self {
         Term::Cons(Box::new(head), Box::new(tail))
     }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -16,39 +16,39 @@ fn sort_values(res: Vec<Term<&str>>) -> Vec<String> {
 #[test]
 fn should_return_multiple_relations() {
     let parent_fn = |parent: Term<_>, child: Term<_>| {
-        let homer = value_term!("Homer");
-        let marge = value_term!("Marge");
-        let bart = value_term!("Bart");
-        let lisa = value_term!("Lisa");
-        let abe = value_term!("Abe");
-        let jackie = value_term!("Jackie");
+        let homer = Term::value("Homer");
+        let marge = Term::value("Marge");
+        let bart = Term::value("Bart");
+        let lisa = Term::value("Lisa");
+        let abe = Term::value("Abe");
+        let jackie = Term::value("Jackie");
 
         either(
             equal(
-                cons_term!(parent.clone(), child.clone()),
-                cons_term!(homer.clone(), bart.clone()),
+                Term::cons(parent.clone(), child.clone()),
+                Term::cons(homer.clone(), bart.clone()),
             ),
             either(
                 equal(
-                    cons_term!(parent.clone(), child.clone()),
-                    cons_term!(homer.clone(), lisa.clone()),
+                    Term::cons(parent.clone(), child.clone()),
+                    Term::cons(homer.clone(), lisa.clone()),
                 ),
                 either(
                     equal(
-                        cons_term!(parent.clone(), child.clone()),
-                        cons_term!(marge.clone(), bart),
+                        Term::cons(parent.clone(), child.clone()),
+                        Term::cons(marge.clone(), bart),
                     ),
                     either(
                         equal(
-                            cons_term!(parent.clone(), child.clone()),
-                            cons_term!(marge.clone(), lisa),
+                            Term::cons(parent.clone(), child.clone()),
+                            Term::cons(marge.clone(), lisa),
                         ),
                         either(
                             equal(
-                                cons_term!(parent.clone(), child.clone()),
-                                cons_term!(abe, homer),
+                                Term::cons(parent.clone(), child.clone()),
+                                Term::cons(abe, homer),
                             ),
-                            equal(cons_term!(parent, child), cons_term!(jackie, marge)),
+                            equal(Term::cons(parent, child), Term::cons(jackie, marge)),
                         ),
                     ),
                 ),
@@ -57,11 +57,11 @@ fn should_return_multiple_relations() {
     };
 
     let children_of_homer = fresh("child", |child| {
-        parent_fn(value_term!("Homer"), var_term!(child))
+        parent_fn(Term::value("Homer"), Term::var(child))
     });
     let stream = children_of_homer.apply(State::empty());
     let child_var = "child".to_var_repr(0);
-    let res = stream.run(&var_term!(child_var));
+    let res = stream.run(&Term::var(child_var));
 
     assert_eq!(stream.len(), 2, "{:?}", res);
     let sorted_children = sort_values(res);
@@ -72,7 +72,7 @@ fn should_return_multiple_relations() {
 
     // map parent relationship
     let parents_of_lisa = fresh("parent", |parent| {
-        parent_fn(var_term!(parent), value_term!("Lisa"))
+        parent_fn(Term::var(parent), Term::value("Lisa"))
     });
     let stream = parents_of_lisa.apply(State::empty());
     let parent_var = "parent".to_var_repr(0);
@@ -90,39 +90,39 @@ fn should_return_multiple_relations() {
 #[test]
 fn should_define_relations_without_fresh() {
     let parent_fn = |parent: Term<_>, child: Term<_>| {
-        let homer = value_term!("Homer");
-        let marge = value_term!("Marge");
-        let bart = value_term!("Bart");
-        let lisa = value_term!("Lisa");
-        let abe = value_term!("Abe");
-        let jackie = value_term!("Jackie");
+        let homer = Term::value("Homer");
+        let marge = Term::value("Marge");
+        let bart = Term::value("Bart");
+        let lisa = Term::value("Lisa");
+        let abe = Term::value("Abe");
+        let jackie = Term::value("Jackie");
 
         either(
             equal(
-                cons_term!(parent.clone(), child.clone()),
-                cons_term!(homer.clone(), bart.clone()),
+                Term::cons(parent.clone(), child.clone()),
+                Term::cons(homer.clone(), bart.clone()),
             ),
             either(
                 equal(
-                    cons_term!(parent.clone(), child.clone()),
-                    cons_term!(homer.clone(), lisa.clone()),
+                    Term::cons(parent.clone(), child.clone()),
+                    Term::cons(homer.clone(), lisa.clone()),
                 ),
                 either(
                     equal(
-                        cons_term!(parent.clone(), child.clone()),
-                        cons_term!(marge.clone(), bart),
+                        Term::cons(parent.clone(), child.clone()),
+                        Term::cons(marge.clone(), bart),
                     ),
                     either(
                         equal(
-                            cons_term!(parent.clone(), child.clone()),
-                            cons_term!(marge.clone(), lisa),
+                            Term::cons(parent.clone(), child.clone()),
+                            Term::cons(marge.clone(), lisa),
                         ),
                         either(
                             equal(
-                                cons_term!(parent.clone(), child.clone()),
-                                cons_term!(abe, homer),
+                                Term::cons(parent.clone(), child.clone()),
+                                Term::cons(abe, homer),
                             ),
-                            equal(cons_term!(parent, child), cons_term!(jackie, marge)),
+                            equal(Term::cons(parent, child), Term::cons(jackie, marge)),
                         ),
                     ),
                 ),
@@ -132,7 +132,7 @@ fn should_define_relations_without_fresh() {
 
     let mut state = State::empty();
     let child = state.declare("child");
-    let children_of_homer = || parent_fn(value_term!("Homer"), var_term!(child));
+    let children_of_homer = || parent_fn(Term::value("Homer"), Term::var(child));
     let stream = children_of_homer().apply(state);
     let res = stream.run(&Term::Var(child));
 
@@ -146,9 +146,9 @@ fn should_define_relations_without_fresh() {
     // map parent relationship
     let mut state = State::empty();
     let parent = state.declare("parent");
-    let parents_of_lisa = parent_fn(var_term!(parent), value_term!("Lisa"));
+    let parents_of_lisa = parent_fn(Term::var(parent), Term::value("Lisa"));
     let stream = parents_of_lisa.apply(state);
-    let res = stream.run(&var_term!(parent));
+    let res = stream.run(&Term::var(parent));
 
     assert_eq!(stream.len(), 2, "{:?}", res);
     let sorted_parents = sort_values(res);


### PR DESCRIPTION
# Introduction
Small Pr to replace the macros for instantiating a term with a much more transparent static constructor method on the `Term`.
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
