### PR TITLE
Experimenting with the interface for the Query DSL

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::hash::Hash;
 
+pub mod query;
+
 /// Any type that can be represented as a `Var`.
 pub trait VarRepresentable: Sized + Clone + Hash + Eq {
     fn to_var_repr(&self, count: usize) -> Var {
@@ -128,7 +130,7 @@ type OccurrenceCounter = HashMap<String, usize>;
 
 /// A state object for a given value that stores mappings of relationships
 /// between `Term`s.
-#[derive(Default, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct State<T: ValueRepresentable> {
     /// tracks the occurrence of a variable of a given representation.
     occurence_counter: OccurrenceCounter,
@@ -240,6 +242,12 @@ impl<T: ValueRepresentable + std::fmt::Debug> std::fmt::Debug for State<T> {
         }
 
         dm.finish()
+    }
+}
+
+impl<T: ValueRepresentable> Default for State<T> {
+    fn default() -> Self {
+        Self::empty()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ impl Var {
 }
 
 /// A Term representing either a Value or Variable or list of Terms.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Term<T: ValueRepresentable> {
     /// Term contains a variable.
     Var(Var),

--- a/src/query.rs
+++ b/src/query.rs
@@ -195,6 +195,23 @@ where
     }
 }
 
+#[derive(Debug)]
+pub struct QueryResult<T>
+where
+    T: ValueRepresentable,
+{
+    stream: Stream<T>,
+}
+
+impl<T> QueryResult<T>
+where
+    T: ValueRepresentable,
+{
+    fn new(stream: Stream<T>) -> Self {
+        Self { stream }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Query<T, V, G>
 where
@@ -220,11 +237,12 @@ where
         }
     }
 
-    pub fn run(self) -> Stream<T> {
+    pub fn run(self) -> QueryResult<T> {
         let state = self.state;
         let goal = self.goal;
 
-        goal.apply(state)
+        let stream = goal.apply(state);
+        QueryResult::new(stream)
     }
 }
 
@@ -260,8 +278,8 @@ mod tests {
                 )
             });
 
-        let stream = query.run();
-        assert_eq!(stream.len(), 1);
-        assert_eq!(stream[0].term_mapping.len(), 2)
+        let result = query.run();
+        assert_eq!(result.stream.len(), 1);
+        assert_eq!(result.stream[0].term_mapping.len(), 2)
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -610,14 +610,14 @@ mod tests {
     fn should_nest_joins() {
         let a = 'a'.to_var_repr(0);
         let b = 'b'.to_var_repr(0);
-        let c = Term::value(0u8);
+        let c = 0u8;
 
-        let first_joined = Join::new(Term::<u8>::var(b), c.clone());
-        let joined = Join::new(a, first_joined);
+        let first_joined = Join::new(AssociatedVar(b), AssociatedValue(c));
+        let joined = Join::new(AssociatedVar(a), first_joined);
 
-        let (a2, (b2, c2)) = joined.unpack();
+        let (a2, (b2, c2)): (Term<u8>, (Term<u8>, Term<u8>)) = joined.unpack();
         assert!(matches!(a2, Term::Var(_)));
         assert!(matches!(b2, Term::Var(_)));
-        assert_eq!(c2, c);
+        assert_eq!(c2, Term::value(c));
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,3 +1,34 @@
+//! The query module provides an extension on top of the kanren engine for
+//! generating queries and relations using a more simple builder pattern.
+//!
+//! # Examples
+//!
+//!  ```
+//! use kannery::*;
+//! use kannery::query::*;;
+//!
+//! let query = QueryBuilder::default()
+//!     .with_var('a')
+//!     .with_var('b')
+//!     .with_term(Term::value(1_u8))
+//!     .build(|((a, b), one)| {
+//!         conjunction(
+//!             conjunction(equal(b.clone(), one.clone()), equal(Term::value(1), one)),
+//!             equal(a, b),
+//!         )
+//!     });
+//!
+//! let result = query.run();
+//! let a_values = result.owned_values_of('a');
+//! let b_values = result.owned_values_of('b');
+//!
+//! // assert all values of a == 1.
+//! assert!(a_values.into_iter().all(|val| val == 1_u8));
+//!
+//! // assert all values of b == 1.
+//! assert!(b_values.into_iter().all(|val| val == 1_u8))
+//! ```
+
 use std::collections::HashSet;
 use std::rc;
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -281,6 +281,35 @@ where
         }
     }
 
+    /// Evaluate a query, returning the results.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kannery::*;
+    /// use kannery::query::*;;
+    ///
+    /// let query = QueryBuilder::default()
+    ///     .with_var('a')
+    ///     .with_var('b')
+    ///     .with_term(Term::value(1_u8))
+    ///     .build(|((a, b), one)| {
+    ///         conjunction(
+    ///             conjunction(equal(b.clone(), one.clone()), equal(Term::value(1), one)),
+    ///             equal(a, b),
+    ///         )
+    ///     });
+    ///
+    /// let result = query.run();
+    /// let a_values = result.values_of('a');
+    /// let b_values = result.values_of('b');
+    ///
+    /// // assert all values of a == 1.
+    /// assert!(a_values.into_iter().all(|val| val.as_ref() == &1_u8));
+    ///
+    /// // assert all values of b == 1.
+    /// assert!(b_values.into_iter().all(|val| val.as_ref() == &1_u8))
+    /// ```
     pub fn run(self) -> QueryResult<T> {
         let state = self.state;
         let goal = self.goal;

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,0 +1,104 @@
+use super::*;
+
+trait VarPackable<B> {
+    fn pack(&self) -> B;
+}
+
+// functions as an identity function.
+impl VarPackable<Var> for Var {
+    fn pack(&self) -> Var {
+        *self
+    }
+}
+
+#[derive(Debug)]
+pub struct Join<V1, V2> {
+    lvar: V1,
+    rvar: V2,
+}
+
+impl<V1, V2> Join<V1, V2> {
+    fn new(lvar: V1, rvar: V2) -> Self {
+        Self { lvar, rvar }
+    }
+}
+
+impl<V1, V2, O1, O2> VarPackable<(O1, O2)> for Join<V1, V2>
+where
+    V1: VarPackable<O1>,
+    V2: VarPackable<O2>,
+{
+    fn pack(&self) -> (O1, O2) {
+        let lhs = self.lvar.pack();
+        let rhs = self.rvar.pack();
+
+        (lhs, rhs)
+    }
+}
+
+trait Runnable<OV, T>
+where
+    T: ValueRepresentable,
+{
+    fn run(&self) -> (OV, Stream<T>);
+}
+
+pub struct Query<T, V, GF>
+where
+    T: ValueRepresentable,
+{
+    vars: V,
+    state: State<T>,
+
+    goal: GF,
+}
+
+impl<T, V, GF> Query<T, V, GF>
+where
+    T: ValueRepresentable,
+{
+    pub fn new(vars: V, state: State<T>, goal: GF) -> Self {
+        Self { vars, goal, state }
+    }
+
+    pub fn with_vars<NV>(self, new_var_repr: NV) -> Query<T, Join<V, Var>, GF>
+    where
+        NV: VarRepresentable + std::fmt::Display,
+    {
+        let mut state = self.state;
+        let prev_vars = self.vars;
+        let goal = self.goal;
+
+        let new_var = state.declare(new_var_repr);
+        let joined_vars = Join::new(prev_vars, new_var);
+
+        Query::new(joined_vars, state, goal)
+    }
+}
+
+impl<OV, T, V, GF, G> Runnable<OV, T> for Query<T, V, GF>
+where
+    T: ValueRepresentable,
+    V: VarPackable<OV>,
+    G: Goal<T>,
+    GF: Fn(OV) -> G,
+{
+    fn run(&self) -> (OV, Stream<T>) {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_nest_joins() {
+        let a = 'a'.to_var_repr(0);
+        let b = 'b'.to_var_repr(0);
+        let c = 'c'.to_var_repr(0);
+
+        let first_joined = Join::new(b, c);
+        let _joined = Join::new(a, first_joined);
+    }
+}

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,5 +1,49 @@
 use kannery::*;
 
+fn parent_child_relationship_goal(
+    parent: Term<&'static str>,
+    child: Term<&'static str>,
+) -> impl Goal<&'static str> {
+    let homer = Term::value("Homer");
+    let marge = Term::value("Marge");
+    let bart = Term::value("Bart");
+    let lisa = Term::value("Lisa");
+    let abe = Term::value("Abe");
+    let jackie = Term::value("Jackie");
+
+    either(
+        equal(
+            Term::cons(parent.clone(), child.clone()),
+            Term::cons(homer.clone(), bart.clone()),
+        ),
+        either(
+            equal(
+                Term::cons(parent.clone(), child.clone()),
+                Term::cons(homer.clone(), lisa.clone()),
+            ),
+            either(
+                equal(
+                    Term::cons(parent.clone(), child.clone()),
+                    Term::cons(marge.clone(), bart),
+                ),
+                either(
+                    equal(
+                        Term::cons(parent.clone(), child.clone()),
+                        Term::cons(marge.clone(), lisa),
+                    ),
+                    either(
+                        equal(
+                            Term::cons(parent.clone(), child.clone()),
+                            Term::cons(abe, homer),
+                        ),
+                        equal(Term::cons(parent, child), Term::cons(jackie, marge)),
+                    ),
+                ),
+            ),
+        ),
+    )
+}
+
 fn sort_values(res: Vec<Term<&str>>) -> Vec<String> {
     let mut elements = res
         .into_iter()
@@ -15,49 +59,8 @@ fn sort_values(res: Vec<Term<&str>>) -> Vec<String> {
 
 #[test]
 fn should_return_multiple_relations() {
-    let parent_fn = |parent: Term<_>, child: Term<_>| {
-        let homer = Term::value("Homer");
-        let marge = Term::value("Marge");
-        let bart = Term::value("Bart");
-        let lisa = Term::value("Lisa");
-        let abe = Term::value("Abe");
-        let jackie = Term::value("Jackie");
-
-        either(
-            equal(
-                Term::cons(parent.clone(), child.clone()),
-                Term::cons(homer.clone(), bart.clone()),
-            ),
-            either(
-                equal(
-                    Term::cons(parent.clone(), child.clone()),
-                    Term::cons(homer.clone(), lisa.clone()),
-                ),
-                either(
-                    equal(
-                        Term::cons(parent.clone(), child.clone()),
-                        Term::cons(marge.clone(), bart),
-                    ),
-                    either(
-                        equal(
-                            Term::cons(parent.clone(), child.clone()),
-                            Term::cons(marge.clone(), lisa),
-                        ),
-                        either(
-                            equal(
-                                Term::cons(parent.clone(), child.clone()),
-                                Term::cons(abe, homer),
-                            ),
-                            equal(Term::cons(parent, child), Term::cons(jackie, marge)),
-                        ),
-                    ),
-                ),
-            ),
-        )
-    };
-
     let children_of_homer = fresh("child", |child| {
-        parent_fn(Term::value("Homer"), Term::var(child))
+        parent_child_relationship_goal(Term::value("Homer"), Term::var(child))
     });
     let stream = children_of_homer.apply(State::empty());
     let child_var = "child".to_var_repr(0);
@@ -72,7 +75,7 @@ fn should_return_multiple_relations() {
 
     // map parent relationship
     let parents_of_lisa = fresh("parent", |parent| {
-        parent_fn(Term::var(parent), Term::value("Lisa"))
+        parent_child_relationship_goal(Term::var(parent), Term::value("Lisa"))
     });
     let stream = parents_of_lisa.apply(State::empty());
     let parent_var = "parent".to_var_repr(0);
@@ -89,51 +92,10 @@ fn should_return_multiple_relations() {
 
 #[test]
 fn should_define_relations_without_fresh() {
-    let parent_fn = |parent: Term<_>, child: Term<_>| {
-        let homer = Term::value("Homer");
-        let marge = Term::value("Marge");
-        let bart = Term::value("Bart");
-        let lisa = Term::value("Lisa");
-        let abe = Term::value("Abe");
-        let jackie = Term::value("Jackie");
-
-        either(
-            equal(
-                Term::cons(parent.clone(), child.clone()),
-                Term::cons(homer.clone(), bart.clone()),
-            ),
-            either(
-                equal(
-                    Term::cons(parent.clone(), child.clone()),
-                    Term::cons(homer.clone(), lisa.clone()),
-                ),
-                either(
-                    equal(
-                        Term::cons(parent.clone(), child.clone()),
-                        Term::cons(marge.clone(), bart),
-                    ),
-                    either(
-                        equal(
-                            Term::cons(parent.clone(), child.clone()),
-                            Term::cons(marge.clone(), lisa),
-                        ),
-                        either(
-                            equal(
-                                Term::cons(parent.clone(), child.clone()),
-                                Term::cons(abe, homer),
-                            ),
-                            equal(Term::cons(parent, child), Term::cons(jackie, marge)),
-                        ),
-                    ),
-                ),
-            ),
-        )
-    };
-
     let mut state = State::empty();
     let child = state.declare("child");
-    let children_of_homer = || parent_fn(Term::value("Homer"), Term::var(child));
-    let stream = children_of_homer().apply(state);
+    let children_of_homer = parent_child_relationship_goal(Term::value("Homer"), Term::var(child));
+    let stream = children_of_homer.apply(state);
     let res = stream.run(&Term::Var(child));
 
     assert_eq!(stream.len(), 2, "{:?}", res);
@@ -146,12 +108,50 @@ fn should_define_relations_without_fresh() {
     // map parent relationship
     let mut state = State::empty();
     let parent = state.declare("parent");
-    let parents_of_lisa = parent_fn(Term::var(parent), Term::value("Lisa"));
+    let parents_of_lisa = parent_child_relationship_goal(Term::var(parent), Term::value("Lisa"));
     let stream = parents_of_lisa.apply(state);
     let res = stream.run(&Term::var(parent));
 
     assert_eq!(stream.len(), 2, "{:?}", res);
     let sorted_parents = sort_values(res);
+
+    assert_eq!(
+        ["Homer".to_string(), "Marge".to_string()].as_slice(),
+        sorted_parents.as_slice()
+    );
+}
+
+#[test]
+fn should_build_query_with_query_dsl() {
+    use kannery::query::*;
+
+    let child_of_homer = QueryBuilder::default()
+        .with_var("child")
+        .build(|child| parent_child_relationship_goal(Term::value("Homer"), child));
+
+    let res = child_of_homer.run();
+    let sorted_children = {
+        let mut children: Vec<_> = res.owned_values_of("child").into_iter().collect();
+        children.sort();
+        children
+    };
+
+    assert_eq!(
+        ["Bart".to_string(), "Lisa".to_string()].as_slice(),
+        sorted_children.as_slice()
+    );
+
+    // map parent relationship
+    let parents_of_lisa = QueryBuilder::default()
+        .with_var("parent")
+        .build(|parent| parent_child_relationship_goal(parent, Term::value("Lisa")));
+
+    let res = parents_of_lisa.run();
+    let sorted_parents = {
+        let mut parents: Vec<_> = res.owned_values_of("parent").into_iter().collect();
+        parents.sort();
+        parents
+    };
 
     assert_eq!(
         ["Homer".to_string(), "Marge".to_string()].as_slice(),

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -68,10 +68,7 @@ fn should_return_multiple_relations() {
 
     assert_eq!(stream.len(), 2, "{:?}", res);
     let sorted_children = sort_values(res);
-    assert_eq!(
-        ["Bart".to_string(), "Lisa".to_string()].as_slice(),
-        sorted_children.as_slice()
-    );
+    assert_eq!(["Bart", "Lisa"].as_slice(), sorted_children.as_slice());
 
     // map parent relationship
     let parents_of_lisa = fresh("parent", |parent| {
@@ -84,10 +81,7 @@ fn should_return_multiple_relations() {
     assert_eq!(stream.len(), 2, "{:?}", res);
     let sorted_parents = sort_values(res);
 
-    assert_eq!(
-        ["Homer".to_string(), "Marge".to_string()].as_slice(),
-        sorted_parents.as_slice()
-    );
+    assert_eq!(["Homer", "Marge"].as_slice(), sorted_parents.as_slice());
 }
 
 #[test]
@@ -115,10 +109,7 @@ fn should_define_relations_without_fresh() {
     assert_eq!(stream.len(), 2, "{:?}", res);
     let sorted_parents = sort_values(res);
 
-    assert_eq!(
-        ["Homer".to_string(), "Marge".to_string()].as_slice(),
-        sorted_parents.as_slice()
-    );
+    assert_eq!(["Homer", "Marge"].as_slice(), sorted_parents.as_slice());
 }
 
 #[test]
@@ -136,10 +127,7 @@ fn should_build_query_with_query_dsl() {
         children
     };
 
-    assert_eq!(
-        ["Bart".to_string(), "Lisa".to_string()].as_slice(),
-        sorted_children.as_slice()
-    );
+    assert_eq!(["Bart", "Lisa"].as_slice(), sorted_children.as_slice());
 
     // map parent relationship
     let parents_of_lisa = QueryBuilder::default()
@@ -153,8 +141,5 @@ fn should_build_query_with_query_dsl() {
         parents
     };
 
-    assert_eq!(
-        ["Homer".to_string(), "Marge".to_string()].as_slice(),
-        sorted_parents.as_slice()
-    );
+    assert_eq!(["Homer", "Marge"].as_slice(), sorted_parents.as_slice());
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -117,8 +117,9 @@ fn should_build_query_with_query_dsl() {
     use kannery::query::*;
 
     let child_of_homer = QueryBuilder::default()
+        .with_value("Homer")
         .with_var("child")
-        .build(|child| parent_child_relationship_goal(Term::value("Homer"), child));
+        .build(|(parent, child)| parent_child_relationship_goal(parent, child));
 
     let res = child_of_homer.run();
     let sorted_children = {
@@ -132,7 +133,8 @@ fn should_build_query_with_query_dsl() {
     // map parent relationship
     let parents_of_lisa = QueryBuilder::default()
         .with_var("parent")
-        .build(|parent| parent_child_relationship_goal(parent, Term::value("Lisa")));
+        .with_value("Lisa")
+        .build(|(parent, child)| parent_child_relationship_goal(parent, child));
 
     let res = parents_of_lisa.run();
     let sorted_parents = {


### PR DESCRIPTION
# Introduction
This PR starts laying out the work on the query dsl as defined in #21 

## Examples

```rust
use kannery::*;
use kannery::query::*;;

let query = QueryBuilder::default()
    .with_var('a')
    .with_var('b')
    .with_term(Term::value(1_u8))
    .build(|((a, b), one)| {
        conjunction(
            conjunction(equal(b.clone(), one.clone()), equal(Term::value(1), one)),
            equal(a, b),
        )
    });

let result = query.run();
let a_values = result.values_of('a');
let b_values = result.values_of('b');

// assert all values of a == 1.
assert!(a_values.into_iter().all(|val| val.as_ref() == &1_u8));

// assert all values of b == 1.
assert!(b_values.into_iter().all(|val| val.as_ref() == &1_u8))
```

```rust
use kannery::*;
use kannery::query::*;;

let query = QueryBuilder::default()
    .with_var('a')
    .with_var('b')
    .with_term(Term::value(1_u8))
    .build(|((a, b), one)| {
        conjunction(
            conjunction(equal(b.clone(), one.clone()), equal(Term::value(1), one)),
            equal(a, b),
        )
    });

let result = query.run();
let a_values = result.owned_values_of('a');
let b_values = result.owned_values_of('b');

// assert all values of a == 1.
assert!(a_values.into_iter().all(|val| val == 1_u8));

// assert all values of b == 1.
assert!(b_values.into_iter().all(|val| val == 1_u8))
```
# Linked Issues
relates to #21 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
