### PR TITLE
Compound goals

### DIFF
--- a/benches/query_construction.rs
+++ b/benches/query_construction.rs
@@ -82,6 +82,38 @@ fn boxed_parent_child_relationship_goal(
     ])
 }
 
+fn relation_construction(c: &mut Criterion) {
+    let mut group = c.benchmark_group("building relations");
+
+    group.bench_function("construction of static relation", |b| {
+        b.iter(|| {
+            let child_of_homer = fresh("child", |child| {
+                parent_child_relationship_goal(Term::value("Homer"), Term::var(child))
+            });
+
+            let stream = child_of_homer.apply(State::empty());
+            let child_var = "child".to_var_repr(0);
+            let children = stream.run(&Term::Var(child_var));
+
+            assert_eq!(children.len(), 2);
+        });
+    });
+
+    group.bench_function("construction of relation from compound goal", |b| {
+        b.iter(|| {
+            let child_of_homer = fresh("child", |child| {
+                parent_child_relationship_goal(Term::value("Homer"), Term::var(child))
+            });
+
+            let stream = child_of_homer.apply(State::empty());
+            let child_var = "child".to_var_repr(0);
+            let children = stream.run(&Term::Var(child_var));
+
+            assert_eq!(children.len(), 2);
+        });
+    });
+}
+
 fn query_construction(c: &mut Criterion) {
     let mut group = c.benchmark_group("query construction");
 
@@ -91,20 +123,6 @@ fn query_construction(c: &mut Criterion) {
                 .with_value("Homer")
                 .with_var("child")
                 .build(|(parent, child)| parent_child_relationship_goal(parent, child));
-
-            let res = child_of_homer.run();
-            let children = res.owned_values_of("child");
-
-            assert_eq!(children.len(), 2);
-        });
-    });
-
-    group.bench_function("construction of boxed (heap-allocated) query", |b| {
-        b.iter(|| {
-            let child_of_homer = QueryBuilder::default()
-                .with_value("Homer")
-                .with_var("child")
-                .build(|(parent, child)| parent_child_relationship_goal(parent, child).to_boxed());
 
             let res = child_of_homer.run();
             let children = res.owned_values_of("child");
@@ -128,5 +146,5 @@ fn query_construction(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, query_construction);
+criterion_group!(benches, relation_construction, query_construction);
 criterion_main!(benches);

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -45,6 +45,42 @@ fn parent_child_relationship_goal(
     )
 }
 
+fn boxed_parent_child_relationship_goal(
+    parent: Term<&'static str>,
+    child: Term<&'static str>,
+) -> impl Goal<&'static str> {
+    let homer = Term::value("Homer");
+    let marge = Term::value("Marge");
+    let bart = Term::value("Bart");
+    let lisa = Term::value("Lisa");
+    let abe = Term::value("Abe");
+    let jackie = Term::value("Jackie");
+
+    any([
+        equal(
+            Term::cons(parent.clone(), child.clone()),
+            Term::cons(homer.clone(), bart.clone()),
+        ),
+        equal(
+            Term::cons(parent.clone(), child.clone()),
+            Term::cons(homer.clone(), lisa.clone()),
+        ),
+        equal(
+            Term::cons(parent.clone(), child.clone()),
+            Term::cons(marge.clone(), bart),
+        ),
+        equal(
+            Term::cons(parent.clone(), child.clone()),
+            Term::cons(marge.clone(), lisa),
+        ),
+        equal(
+            Term::cons(parent.clone(), child.clone()),
+            Term::cons(abe, homer),
+        ),
+        equal(Term::cons(parent, child), Term::cons(jackie, marge)),
+    ])
+}
+
 fn sort_values(res: Vec<Term<&str>>) -> Vec<String> {
     let mut elements = res
         .into_iter()
@@ -136,6 +172,67 @@ fn should_build_query_with_query_dsl() {
         .with_var("parent")
         .with_value("Lisa")
         .build(|(parent, child)| parent_child_relationship_goal(parent, child));
+
+    let res = parents_of_lisa.run();
+    let sorted_parents = {
+        let mut parents: Vec<_> = res.owned_values_of("parent").into_iter().collect();
+        parents.sort();
+        parents
+    };
+
+    assert_eq!(["Homer", "Marge"].as_slice(), sorted_parents.as_slice());
+}
+
+#[test]
+fn should_return_multiple_relations_from_boxed_expression() {
+    let children_of_homer = fresh("child", |child| {
+        boxed_parent_child_relationship_goal(Term::value("Homer"), Term::var(child))
+    });
+    let stream = children_of_homer.apply(State::empty());
+    let child_var = "child".to_var_repr(0);
+    let res = stream.run(&Term::var(child_var));
+
+    assert_eq!(stream.len(), 2, "{:?}", res);
+    let sorted_children = sort_values(res);
+    assert_eq!(["Bart", "Lisa"].as_slice(), sorted_children.as_slice());
+
+    // map parent relationship
+    let parents_of_lisa = fresh("parent", |parent| {
+        boxed_parent_child_relationship_goal(Term::var(parent), Term::value("Lisa"))
+    });
+    let stream = parents_of_lisa.apply(State::empty());
+    let parent_var = "parent".to_var_repr(0);
+    let res = stream.run(&Term::Var(parent_var));
+
+    assert_eq!(stream.len(), 2, "{:?}", res);
+    let sorted_parents = sort_values(res);
+
+    assert_eq!(["Homer", "Marge"].as_slice(), sorted_parents.as_slice());
+}
+
+#[test]
+fn should_build_query_with_query_dsl_using_boxed_goals() {
+    use kannery::*;
+
+    let child_of_homer = QueryBuilder::default()
+        .with_value("Homer")
+        .with_var("child")
+        .build(|(parent, child)| boxed_parent_child_relationship_goal(parent, child));
+
+    let res = child_of_homer.run();
+    let sorted_children = {
+        let mut children: Vec<_> = res.owned_values_of("child").into_iter().collect();
+        children.sort();
+        children
+    };
+
+    assert_eq!(["Bart", "Lisa"].as_slice(), sorted_children.as_slice());
+
+    // map parent relationship
+    let parents_of_lisa = QueryBuilder::default()
+        .with_var("parent")
+        .with_value("Lisa")
+        .build(|(parent, child)| boxed_parent_child_relationship_goal(parent, child));
 
     let res = parents_of_lisa.run();
     let sorted_parents = {


### PR DESCRIPTION
# Introduction
This PR introduces compound goals, for disjunction and conjunction relations that make use of the new boxed goals allowing an arbitrary number of goals to be captured in an array/vec of relations.

# Linked Issues
resolves #29 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
