### PR TITLE
fix: remove redundant into_iterator method on range iterator

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -447,7 +447,6 @@ where
                 let count = state.occurence_counter.get(&var_repr).copied()?;
 
                 let state_iter = (0..=(count))
-                    .into_iter()
                     .flat_map(|occ_count| state.term_mapping.get(&var.to_var_repr(occ_count)));
 
                 Some(state_iter)
@@ -506,7 +505,6 @@ where
                 let count = state.occurence_counter.get(&var_repr).copied()?;
 
                 let state_iter = (0..=(count))
-                    .into_iter()
                     .flat_map(|occ_count| state.term_mapping.get(&var.to_var_repr(occ_count)));
 
                 Some(state_iter)


### PR DESCRIPTION
# Introduction
Small PR to correct rendundant `into_iterator` calls on ranges.
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
